### PR TITLE
Fixes creating curl from request with multiple cookies

### DIFF
--- a/FormatterKit/TTTURLRequestFormatter.m
+++ b/FormatterKit/TTTURLRequestFormatter.m
@@ -63,8 +63,12 @@
 
     if ([request URL]) {
         NSArray *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:[request URL]];
-        for (NSHTTPCookie *cookie in cookies) {
-            [command appendCommandLineArgument:[NSString stringWithFormat:@"--cookie \"%@=%@\"", [cookie name], [cookie value]]];
+        if (cookies.count) {
+            NSMutableString *cookiesString = [NSMutableString string];
+            for (NSHTTPCookie *cookie in cookies) {
+                [cookiesString appendFormat:@"%@=%@;", [cookie name], [cookie value]];
+            }
+            [command appendCommandLineArgument:[NSString stringWithFormat:@"--cookie \"%@\"", cookiesString]];
         }
     }
 


### PR DESCRIPTION
From `$ man curl`:
```
-b, --cookie <name=data>
(HTTP)  Pass  the  data to the HTTP server as a cookie. It is supposedly the data previously received
from the server  in  a  "Set-Cookie:"  line.   The  data  should  be  in  the  format  "NAME1=VALUE1;
NAME2=VALUE2".

If  no  '='  symbol is used in the line, it is treated as a filename to use to read previously stored
cookie lines from, which should be used in this session if they match. Using this method  also  acti-
vates  the  "cookie  parser"  which will make curl record incoming cookies too, which may be handy if
you're using this in combination with the -L, --location option. The file format of the file to  read
cookies from should be plain HTTP headers or the Netscape/Mozilla cookie file format.

NOTE  that  the  file specified with -b, --cookie is only used as input. No cookies will be stored in
the file. To store cookies, use the -c, --cookie-jar option or you could even save the  HTTP  headers
to a file using -D, --dump-header!

If this option is used several times, the last one will be used.
```