### PR TITLE
Use a "resources" subspec to make resources copied only once

### DIFF
--- a/FormatterKit.podspec
+++ b/FormatterKit.podspec
@@ -14,52 +14,56 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
+  s.subspec 'Resources' do |ss|
+    ss.resources = 'Localizations/**'
+  end
+
   s.subspec 'AddressFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTAddressFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
     ss.osx.frameworks = 'AddressBook'
     ss.ios.frameworks = 'AddressBook', 'AddressBookUI'
+    ss.dependency 'FormatterKit/Resources'
   end
 
   s.subspec 'ArrayFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTArrayFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
   end
 
   s.subspec 'ColorFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTColorFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
   end
 
   s.subspec 'LocationFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTLocationFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
     ss.frameworks = 'CoreLocation'
   end
 
   s.subspec 'NameFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTNameFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
     ss.ios.frameworks = 'AddressBook'
   end
 
   s.subspec 'OrdinalNumberFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTOrdinalNumberFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
   end
 
   s.subspec 'TimeIntervalFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTTimeIntervalFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
   end
 
   s.subspec 'UnitOfInformationFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTUnitOfInformationFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
   end
 
   s.subspec 'URLRequestFormatter' do |ss|
     ss.source_files = 'FormatterKit/TTTURLRequestFormatter.{h,m}'
-    ss.resources = 'Localizations/**'
+    ss.dependency 'FormatterKit/Resources'
   end
 end


### PR DESCRIPTION
Original podspec makes the resources files copied multiple times.
Hence, if I installed all the 9 subspecs, those resources files are also copied 9 times.
(By checking ```Pods/Target Support Files/Pods/Pods-resources.sh``` generated by cocoapods 0.35.0)

This fix creates a subspec to copy resource files (```*.lproj```), and makes other subspec dependent on it.