### PR TITLE
Fix NSCalendarUnitCompareSignificance method

### DIFF
--- a/FormatterKit/TTTTimeIntervalFormatter.m
+++ b/FormatterKit/TTTTimeIntervalFormatter.m
@@ -66,7 +66,7 @@ static inline NSCalendarUnit NSCalendarUnitFromString(NSString *string) {
 
 static inline NSComparisonResult NSCalendarUnitCompareSignificance(NSCalendarUnit a, NSCalendarUnit b) {
     if ((a == TTTCalendarUnitWeek) ^ (b == TTTCalendarUnitWeek)) {
-        if (a == TTTCalendarUnitWeek) {
+        if (b == TTTCalendarUnitWeek) {
             switch (a) {
                 case TTTCalendarUnitYear:
                 case TTTCalendarUnitMonth:


### PR DESCRIPTION
Hi, Mattt!
Found bug in `NSCalendarUnit` comparasion.
After check `a == TTTCalendarUnitWeek` no sence to have a switch `switch (a)` it should be **`b == TTTCalendarUnitWeek``**.

Check diff for more info - it's simple.