### PR TITLE
Add support for Swedish (sv) ordinal numbers.

### DIFF
--- a/Example/FormatterKit Example/OrdinalNumberFormatterViewController.m
+++ b/Example/FormatterKit Example/OrdinalNumberFormatterViewController.m
@@ -51,6 +51,7 @@
     [mutableLocales addObject:[[NSLocale alloc] initWithLocaleIdentifier:@"pt_PT"]];
     [mutableLocales addObject:[[NSLocale alloc] initWithLocaleIdentifier:@"zh-Hant_CN"]];
     [mutableLocales addObject:[[NSLocale alloc] initWithLocaleIdentifier:@"ca_ES"]];
+    [mutableLocales addObject:[[NSLocale alloc] initWithLocaleIdentifier:@"sv_SE"]];
     self.locales = [NSArray arrayWithArray:mutableLocales];
 
     return self;
@@ -58,7 +59,7 @@
 
 
 + (NSString *)formatterDescription {
-    return NSLocalizedString(@"TTTOrdinalNumberFormatter formats cardinals (1, 2, 3, etc.) into ordinals (1st, 2nd, 3rd, etc.), and supports English, Spanish, French, German, Irish, Italian, Japanese, Dutch, Portuguese, and Mandarin Chinese. For other languages, you can use the standard default, or override it with your own. For languages whose ordinal indicator depends upon the grammatical properties of the predicate, TTTOrdinalNumberFormatter can format according to a specified gender and/or plurality.", nil);
+    return NSLocalizedString(@"TTTOrdinalNumberFormatter formats cardinals (1, 2, 3, etc.) into ordinals (1st, 2nd, 3rd, etc.), and supports English, Spanish, French, German, Irish, Italian, Japanese, Dutch, Portuguese, Mandarin Chinese and Swedish. For other languages, you can use the standard default, or override it with your own. For languages whose ordinal indicator depends upon the grammatical properties of the predicate, TTTOrdinalNumberFormatter can format according to a specified gender and/or plurality.", nil);
 }
 
 #pragma mark - UITableViewDataSource

--- a/FormatterKit/TTTOrdinalNumberFormatter.m
+++ b/FormatterKit/TTTOrdinalNumberFormatter.m
@@ -69,6 +69,8 @@ static NSString * const kTTTOrdinalNumberFormatterDefaultOrdinalIndicator = @"."
         return [self zhHansOrdinalIndicatorStringFromNumber:number];
     } else if ([languageCode isEqualToString:@"ca"]) {
         return [self caOrdinalIndicatorStringFromNumber:number];
+    } else if ([languageCode isEqualToString:@"sv"]) {
+        return [self svOrdinalIndicatorStringFromNumber:number];
     } else {
         return kTTTOrdinalNumberFormatterDefaultOrdinalIndicator;
     }
@@ -211,6 +213,23 @@ static NSString * const kTTTOrdinalNumberFormatterDefaultOrdinalIndicator = @"."
 
 - (NSString *)zhHansOrdinalIndicatorStringFromNumber:(__unused NSNumber *)number {
     return @"\u7B2C"; // Unicode Han Character 'sequence, number; grade, degree'
+}
+
+- (NSString *)svOrdinalIndicatorStringFromNumber:(NSNumber *)number {
+    // If number % 100 is 11 or 12, ordinals are 11:e and 12:e.
+    if (NSLocationInRange([number integerValue] % 100, NSMakeRange(11, 2))) {
+        return @":e";
+    }
+    
+    // 1:a, 2:a, 3:e, 4:e and so on. Also, 21:a, 22:a, 23:e ...
+    switch ([number integerValue] % 10) {
+        case 1:
+            return @":a";
+        case 2:
+            return @":a";
+        default:
+            return @":e";
+    }
 }
 
 #pragma mark - NSFormatter

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ NSLog(@"%@", japaneseName);
 
 A naïve implementation might be as simple as throwing the one's place in a switch statement and appending "-st", "-nd", etc. But what if you want to support French, which appends "-er", "-ère", and "-eme" in various contexts? How about Spanish? Japanese?
 
-`TTTOrdinalNumberFormatter` supports English, Spanish, French, German, Irish, Italian, Japanese, Dutch, Portuguese, and Simplified Chinese. For other languages, you can use the standard default, or override it with your own. For languages whose ordinal indicator depends upon the grammatical properties of the predicate, `TTTOrdinalNumberFormatter` can format according to a specified gender and/or plurality.
+`TTTOrdinalNumberFormatter` supports English, Spanish, French, German, Irish, Italian, Japanese, Dutch, Portuguese, Simplified Chinese and Swedish. For other languages, you can use the standard default, or override it with your own. For languages whose ordinal indicator depends upon the grammatical properties of the predicate, `TTTOrdinalNumberFormatter` can format according to a specified gender and/or plurality.
 
 ### Example Usage
 


### PR DESCRIPTION
I added support for ordinal numbers in Swedish. I don't know if this is interesting at all, but thought it might be.

There is more information [on Wikipedia](http://en.wikipedia.org/wiki/Ordinal_indicator#Other_languages) if you wish to verify (scroll down a little). It is similar to the English, anyway.

// E. G.