### PR TITLE
Incorrect calendar unit comparison.

### DIFF
--- a/FormatterKit/TTTTimeIntervalFormatter.m
+++ b/FormatterKit/TTTTimeIntervalFormatter.m
@@ -70,17 +70,17 @@ static inline NSComparisonResult NSCalendarUnitCompareSignificance(NSCalendarUni
             switch (a) {
                 case TTTCalendarUnitYear:
                 case TTTCalendarUnitMonth:
-                    return NSOrderedAscending;
-                default:
                     return NSOrderedDescending;
+                default:
+                    return NSOrderedAscending;
             }
         } else {
             switch (b) {
                 case TTTCalendarUnitYear:
                 case TTTCalendarUnitMonth:
-                    return NSOrderedDescending;
-                default:
                     return NSOrderedAscending;
+                default:
+                    return NSOrderedDescending;
             }
         }
     } else {


### PR DESCRIPTION
Calendar unit comparison for weekOfYear with year, month is uncorrected
now. Current ordered is ascending when compare second vs minute , day,
month, year. But it’s descending for weekOfYear vs year, month.

Just do a fix to correct the order of calendar unit.