### PR TITLE
formatting color with a hex number instead of a string

### DIFF
--- a/FormatterKit/TTTColorFormatter.h
+++ b/FormatterKit/TTTColorFormatter.h
@@ -61,6 +61,15 @@
  */
 - (UIColor *)colorFromHexadecimalString:(NSString *)string;
 
+/**
+ Returns the color represented by the specified integerd.
+ 
+ @param numeric string for color
+ 
+ @return The color
+ */
+- (UIColor *)colorFromHexadecimalNumber:(NSInteger)integer;
+
 ///----------
 /// @name RGB
 ///----------

--- a/FormatterKit/TTTColorFormatter.m
+++ b/FormatterKit/TTTColorFormatter.m
@@ -100,10 +100,15 @@ static void TTTGetHSLComponentsFromColor(UIColor *color, CGFloat *hue, CGFloat *
     unsigned value;
     [scanner scanHexInt:&value];
 
-    CGFloat r = ((value & 0xFF0000) >> 16) / 255.0f;
-    CGFloat g = ((value & 0xFF00) >> 8) / 255.0f;
-    CGFloat b = ((value & 0xFF)) / 255.0f;
+    return [self colorFromHexadecimalNumber:value];
+}
 
+-(UIColor *)colorFromHexadecimalNumber:(NSInteger)integer
+{
+    CGFloat r = ((integer & 0xFF0000) >> 16) / 255.0f;
+    CGFloat g = ((integer & 0xFF00) >> 8) / 255.0f;
+    CGFloat b = ((integer & 0xFF)) / 255.0f;
+    
     return [UIColor colorWithRed:r green:g blue:b alpha:1.0];
 }
 


### PR DESCRIPTION
Allows you to specify a color with just a hex number. 
Something like 0xFECD89