### PR TITLE
non-abbreviated 'day'/'days' for german locale

### DIFF
--- a/Localizations/de.lproj/FormatterKit.strings
+++ b/Localizations/de.lproj/FormatterKit.strings
@@ -30,11 +30,11 @@
 
 /* Day Unit (Singular)
    Day Unit (Singular, Abbreviated) */
-"day" = "T.";
+"day" = "Tag";
 
 /* Day Unit (Plural)
    Day Unit (Plural, Abbreviated) */
-"days" = "T.";
+"days" = "Tage";
 
 /* East Direction Abbreviation */
 "E" = "O";

--- a/Localizations/de.lproj/FormatterKit.strings
+++ b/Localizations/de.lproj/FormatterKit.strings
@@ -34,7 +34,7 @@
 
 /* Day Unit (Plural)
    Day Unit (Plural, Abbreviated) */
-"days" = "Tage";
+"days" = "Tagen";
 
 /* East Direction Abbreviation */
 "E" = "O";


### PR DESCRIPTION
Previously, time intervals with "day" units would always be abbreviated in the German localisation. With this change, they are always written unabbreviated which should be more appropriate for most usage scenarios. Ideally, abbreviated and unabbreviated usage should both be configurable.
