### PR TITLE
Remove unused localizations using `pre_install` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,16 @@ Because the App Store automatically attempts to determine supported locales, and
 If you are using CocoaPods, you may want to remove unwanted localizations using the pre install script below. Modify the supported_locales array to match your supported locales and paste it into your Podfile.
 
 ```ruby
-prepare_command = <<-CMD
-    SUPPORTED_LOCALES="['base', 'da', 'en']"
-    find . -type d ! -name "*$SUPPORTED_LOCALES.lproj" | grep .lproj | xargs rm -rf
-CMD
+pre_install do |installer|
+    supported_locales = ['base', 'da', 'en']
+    
+    Dir.glob(File.join(installer.sandbox.pod_dir('FormatterKit'), '**', '*.lproj')).each do |bundle|
+        if (!supported_locales.include?(File.basename(bundle, ".lproj").downcase))
+            puts "Removing #{bundle}"
+            FileUtils.rm_rf(bundle)
+        end
+    end
+end
 ```
 
 ## Demo


### PR DESCRIPTION
`prepare_command` works only in podspec. Latest CocoaPods have changed interface of `installer`, so original hook wasn't working. Tested on CocoaPods 0.38.2.