### PR TITLE
Support Frameworks

### DIFF
--- a/Example/FormatterKit Example.xcodeproj/project.pbxproj
+++ b/Example/FormatterKit Example.xcodeproj/project.pbxproj
@@ -10,19 +10,19 @@
 		500C0A6D1C948B5500F643D3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 500C0A6C1C948B5500F643D3 /* Main.storyboard */; };
 		502B4F441C686832007347C5 /* TTTTimeIntervalFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502B4F431C686832007347C5 /* TTTTimeIntervalFormatterTests.swift */; };
 		50E226D81C6863BF0088FAA5 /* AppDeletage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E226D71C6863BF0088FAA5 /* AppDeletage.swift */; };
-		F8202D0917F4FAAE006C5810 /* TTTColorFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F8202D0817F4FAAE006C5810 /* TTTColorFormatter.m */; };
+		5B31FE551CA6B4D400309D75 /* TTTAddressFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE441CA6B4D400309D75 /* TTTAddressFormatter.m */; };
+		5B31FE561CA6B4D400309D75 /* TTTArrayFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE461CA6B4D400309D75 /* TTTArrayFormatter.m */; };
+		5B31FE571CA6B4D400309D75 /* TTTColorFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE481CA6B4D400309D75 /* TTTColorFormatter.m */; };
+		5B31FE581CA6B4D400309D75 /* TTTLocationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE4A1CA6B4D400309D75 /* TTTLocationFormatter.m */; };
+		5B31FE591CA6B4D400309D75 /* TTTNameFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE4C1CA6B4D400309D75 /* TTTNameFormatter.m */; };
+		5B31FE5A1CA6B4D400309D75 /* TTTOrdinalNumberFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE4E1CA6B4D400309D75 /* TTTOrdinalNumberFormatter.m */; };
+		5B31FE5B1CA6B4D400309D75 /* TTTTimeIntervalFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE501CA6B4D400309D75 /* TTTTimeIntervalFormatter.m */; };
+		5B31FE5C1CA6B4D400309D75 /* TTTUnitOfInformationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE521CA6B4D400309D75 /* TTTUnitOfInformationFormatter.m */; };
+		5B31FE5D1CA6B4D400309D75 /* TTTURLRequestFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B31FE541CA6B4D400309D75 /* TTTURLRequestFormatter.m */; };
 		F8202D0C17F50AF5006C5810 /* ColorFormatterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F8202D0B17F50AF5006C5810 /* ColorFormatterViewController.m */; };
 		F83F967F1982DAB90012B3AF /* NameFormatterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F83F967E1982DAB90012B3AF /* NameFormatterViewController.m */; };
-		F83F96821982DADF0012B3AF /* TTTNameFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F83F96811982DADF0012B3AF /* TTTNameFormatter.m */; };
 		F872625414FD3BED00800E11 /* UnitOfInformationFormatterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F872625314FD3BED00800E11 /* UnitOfInformationFormatterViewController.m */; };
 		F892375416A4BE43002FCF70 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F892375316A4BE43002FCF70 /* Default-568h@2x.png */; };
-		F89C9F02166154AB0040FB03 /* TTTAddressFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89C9EF5166154AB0040FB03 /* TTTAddressFormatter.m */; };
-		F89C9F03166154AB0040FB03 /* TTTArrayFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89C9EF7166154AB0040FB03 /* TTTArrayFormatter.m */; };
-		F89C9F04166154AB0040FB03 /* TTTLocationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89C9EF9166154AB0040FB03 /* TTTLocationFormatter.m */; };
-		F89C9F05166154AB0040FB03 /* TTTOrdinalNumberFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89C9EFB166154AB0040FB03 /* TTTOrdinalNumberFormatter.m */; };
-		F89C9F06166154AB0040FB03 /* TTTTimeIntervalFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89C9EFD166154AB0040FB03 /* TTTTimeIntervalFormatter.m */; };
-		F89C9F07166154AB0040FB03 /* TTTUnitOfInformationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89C9EFF166154AB0040FB03 /* TTTUnitOfInformationFormatter.m */; };
-		F89C9F08166154AB0040FB03 /* TTTURLRequestFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89C9F01166154AB0040FB03 /* TTTURLRequestFormatter.m */; };
 		F8A847A0161E93D800940F39 /* AddressBookUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A8479F161E93D800940F39 /* AddressBookUI.framework */; };
 		F8A847A6161E982500940F39 /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8A847A5161E982500940F39 /* AddressBook.framework */; };
 		F8A847A9161E98D800940F39 /* AddressFormatterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A847A8161E98D800940F39 /* AddressFormatterViewController.m */; };
@@ -56,33 +56,33 @@
 		504295101C683A6300143D6F /* FormatterKitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FormatterKitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		504295131C683A9C00143D6F /* FormatterKit Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FormatterKit Example-Bridging-Header.h"; sourceTree = "<group>"; };
 		50E226D71C6863BF0088FAA5 /* AppDeletage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDeletage.swift; sourceTree = "<group>"; };
+		5B31FE431CA6B4D400309D75 /* TTTAddressFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTAddressFormatter.h; sourceTree = "<group>"; };
+		5B31FE441CA6B4D400309D75 /* TTTAddressFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTAddressFormatter.m; sourceTree = "<group>"; };
+		5B31FE451CA6B4D400309D75 /* TTTArrayFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTArrayFormatter.h; sourceTree = "<group>"; };
+		5B31FE461CA6B4D400309D75 /* TTTArrayFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTArrayFormatter.m; sourceTree = "<group>"; };
+		5B31FE471CA6B4D400309D75 /* TTTColorFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTColorFormatter.h; sourceTree = "<group>"; };
+		5B31FE481CA6B4D400309D75 /* TTTColorFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTColorFormatter.m; sourceTree = "<group>"; };
+		5B31FE491CA6B4D400309D75 /* TTTLocationFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTLocationFormatter.h; sourceTree = "<group>"; };
+		5B31FE4A1CA6B4D400309D75 /* TTTLocationFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTLocationFormatter.m; sourceTree = "<group>"; };
+		5B31FE4B1CA6B4D400309D75 /* TTTNameFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTNameFormatter.h; sourceTree = "<group>"; };
+		5B31FE4C1CA6B4D400309D75 /* TTTNameFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTNameFormatter.m; sourceTree = "<group>"; };
+		5B31FE4D1CA6B4D400309D75 /* TTTOrdinalNumberFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTOrdinalNumberFormatter.h; sourceTree = "<group>"; };
+		5B31FE4E1CA6B4D400309D75 /* TTTOrdinalNumberFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTOrdinalNumberFormatter.m; sourceTree = "<group>"; };
+		5B31FE4F1CA6B4D400309D75 /* TTTTimeIntervalFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTTimeIntervalFormatter.h; sourceTree = "<group>"; };
+		5B31FE501CA6B4D400309D75 /* TTTTimeIntervalFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTTimeIntervalFormatter.m; sourceTree = "<group>"; };
+		5B31FE511CA6B4D400309D75 /* TTTUnitOfInformationFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTUnitOfInformationFormatter.h; sourceTree = "<group>"; };
+		5B31FE521CA6B4D400309D75 /* TTTUnitOfInformationFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTUnitOfInformationFormatter.m; sourceTree = "<group>"; };
+		5B31FE531CA6B4D400309D75 /* TTTURLRequestFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTURLRequestFormatter.h; sourceTree = "<group>"; };
+		5B31FE541CA6B4D400309D75 /* TTTURLRequestFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTURLRequestFormatter.m; sourceTree = "<group>"; };
 		659BF4B71AE27FA300CD4A06 /* FormatterKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FormatterKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		659BF4BA1AE27FA300CD4A06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F8202D0717F4FAAE006C5810 /* TTTColorFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTColorFormatter.h; sourceTree = "<group>"; };
-		F8202D0817F4FAAE006C5810 /* TTTColorFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTColorFormatter.m; sourceTree = "<group>"; };
 		F8202D0A17F50AF5006C5810 /* ColorFormatterViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorFormatterViewController.h; sourceTree = "<group>"; };
 		F8202D0B17F50AF5006C5810 /* ColorFormatterViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ColorFormatterViewController.m; sourceTree = "<group>"; };
 		F83F967D1982DAB90012B3AF /* NameFormatterViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NameFormatterViewController.h; sourceTree = "<group>"; };
 		F83F967E1982DAB90012B3AF /* NameFormatterViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NameFormatterViewController.m; sourceTree = "<group>"; };
-		F83F96801982DADF0012B3AF /* TTTNameFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTNameFormatter.h; sourceTree = "<group>"; };
-		F83F96811982DADF0012B3AF /* TTTNameFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTNameFormatter.m; sourceTree = "<group>"; };
 		F872625214FD3BED00800E11 /* UnitOfInformationFormatterViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnitOfInformationFormatterViewController.h; sourceTree = "<group>"; };
 		F872625314FD3BED00800E11 /* UnitOfInformationFormatterViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UnitOfInformationFormatterViewController.m; sourceTree = "<group>"; };
 		F892375316A4BE43002FCF70 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
-		F89C9EF4166154AB0040FB03 /* TTTAddressFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTAddressFormatter.h; sourceTree = "<group>"; };
-		F89C9EF5166154AB0040FB03 /* TTTAddressFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTAddressFormatter.m; sourceTree = "<group>"; };
-		F89C9EF6166154AB0040FB03 /* TTTArrayFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTArrayFormatter.h; sourceTree = "<group>"; };
-		F89C9EF7166154AB0040FB03 /* TTTArrayFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTArrayFormatter.m; sourceTree = "<group>"; };
-		F89C9EF8166154AB0040FB03 /* TTTLocationFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTLocationFormatter.h; sourceTree = "<group>"; };
-		F89C9EF9166154AB0040FB03 /* TTTLocationFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTLocationFormatter.m; sourceTree = "<group>"; };
-		F89C9EFA166154AB0040FB03 /* TTTOrdinalNumberFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTOrdinalNumberFormatter.h; sourceTree = "<group>"; };
-		F89C9EFB166154AB0040FB03 /* TTTOrdinalNumberFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTOrdinalNumberFormatter.m; sourceTree = "<group>"; };
-		F89C9EFC166154AB0040FB03 /* TTTTimeIntervalFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTTimeIntervalFormatter.h; sourceTree = "<group>"; };
-		F89C9EFD166154AB0040FB03 /* TTTTimeIntervalFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTTimeIntervalFormatter.m; sourceTree = "<group>"; };
-		F89C9EFE166154AB0040FB03 /* TTTUnitOfInformationFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTUnitOfInformationFormatter.h; sourceTree = "<group>"; };
-		F89C9EFF166154AB0040FB03 /* TTTUnitOfInformationFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTUnitOfInformationFormatter.m; sourceTree = "<group>"; };
-		F89C9F00166154AB0040FB03 /* TTTURLRequestFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTURLRequestFormatter.h; sourceTree = "<group>"; };
-		F89C9F01166154AB0040FB03 /* TTTURLRequestFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTURLRequestFormatter.m; sourceTree = "<group>"; };
 		F8A8479F161E93D800940F39 /* AddressBookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBookUI.framework; path = System/Library/Frameworks/AddressBookUI.framework; sourceTree = SDKROOT; };
 		F8A847A5161E982500940F39 /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
 		F8A847A7161E98D800940F39 /* AddressFormatterViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddressFormatterViewController.h; sourceTree = "<group>"; };
@@ -156,24 +156,24 @@
 		F89C9EF3166154AB0040FB03 /* FormatterKit */ = {
 			isa = PBXGroup;
 			children = (
-				F89C9EF4166154AB0040FB03 /* TTTAddressFormatter.h */,
-				F89C9EF5166154AB0040FB03 /* TTTAddressFormatter.m */,
-				F89C9EF6166154AB0040FB03 /* TTTArrayFormatter.h */,
-				F89C9EF7166154AB0040FB03 /* TTTArrayFormatter.m */,
-				F8202D0717F4FAAE006C5810 /* TTTColorFormatter.h */,
-				F8202D0817F4FAAE006C5810 /* TTTColorFormatter.m */,
-				F89C9EF8166154AB0040FB03 /* TTTLocationFormatter.h */,
-				F89C9EF9166154AB0040FB03 /* TTTLocationFormatter.m */,
-				F83F96801982DADF0012B3AF /* TTTNameFormatter.h */,
-				F83F96811982DADF0012B3AF /* TTTNameFormatter.m */,
-				F89C9EFA166154AB0040FB03 /* TTTOrdinalNumberFormatter.h */,
-				F89C9EFB166154AB0040FB03 /* TTTOrdinalNumberFormatter.m */,
-				F89C9EFC166154AB0040FB03 /* TTTTimeIntervalFormatter.h */,
-				F89C9EFD166154AB0040FB03 /* TTTTimeIntervalFormatter.m */,
-				F89C9EFE166154AB0040FB03 /* TTTUnitOfInformationFormatter.h */,
-				F89C9EFF166154AB0040FB03 /* TTTUnitOfInformationFormatter.m */,
-				F89C9F00166154AB0040FB03 /* TTTURLRequestFormatter.h */,
-				F89C9F01166154AB0040FB03 /* TTTURLRequestFormatter.m */,
+				5B31FE431CA6B4D400309D75 /* TTTAddressFormatter.h */,
+				5B31FE441CA6B4D400309D75 /* TTTAddressFormatter.m */,
+				5B31FE451CA6B4D400309D75 /* TTTArrayFormatter.h */,
+				5B31FE461CA6B4D400309D75 /* TTTArrayFormatter.m */,
+				5B31FE471CA6B4D400309D75 /* TTTColorFormatter.h */,
+				5B31FE481CA6B4D400309D75 /* TTTColorFormatter.m */,
+				5B31FE491CA6B4D400309D75 /* TTTLocationFormatter.h */,
+				5B31FE4A1CA6B4D400309D75 /* TTTLocationFormatter.m */,
+				5B31FE4B1CA6B4D400309D75 /* TTTNameFormatter.h */,
+				5B31FE4C1CA6B4D400309D75 /* TTTNameFormatter.m */,
+				5B31FE4D1CA6B4D400309D75 /* TTTOrdinalNumberFormatter.h */,
+				5B31FE4E1CA6B4D400309D75 /* TTTOrdinalNumberFormatter.m */,
+				5B31FE4F1CA6B4D400309D75 /* TTTTimeIntervalFormatter.h */,
+				5B31FE501CA6B4D400309D75 /* TTTTimeIntervalFormatter.m */,
+				5B31FE511CA6B4D400309D75 /* TTTUnitOfInformationFormatter.h */,
+				5B31FE521CA6B4D400309D75 /* TTTUnitOfInformationFormatter.m */,
+				5B31FE531CA6B4D400309D75 /* TTTURLRequestFormatter.h */,
+				5B31FE541CA6B4D400309D75 /* TTTURLRequestFormatter.m */,
 			);
 			name = FormatterKit;
 			path = ../FormatterKit;
@@ -388,27 +388,27 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B31FE5A1CA6B4D400309D75 /* TTTOrdinalNumberFormatter.m in Sources */,
+				5B31FE5B1CA6B4D400309D75 /* TTTTimeIntervalFormatter.m in Sources */,
+				5B31FE551CA6B4D400309D75 /* TTTAddressFormatter.m in Sources */,
+				5B31FE561CA6B4D400309D75 /* TTTArrayFormatter.m in Sources */,
 				F8FBFA351427CEC0001409DB /* RootViewController.m in Sources */,
 				F8FBFA381427D159001409DB /* FormatterViewController.m in Sources */,
 				F8FBFA3B1427D3DA001409DB /* ArrayFormatterViewController.m in Sources */,
+				5B31FE591CA6B4D400309D75 /* TTTNameFormatter.m in Sources */,
+				5B31FE571CA6B4D400309D75 /* TTTColorFormatter.m in Sources */,
 				F8FBFA421427E1DC001409DB /* LocationFormatterViewController.m in Sources */,
 				F8FBFA451427E21C001409DB /* OrdinalNumberFormatterViewController.m in Sources */,
 				F8FBFA481427E23C001409DB /* TimeIntervalFormatterViewController.m in Sources */,
 				F8FBFA4B1427E260001409DB /* URLRequestFormatterViewController.m in Sources */,
+				5B31FE581CA6B4D400309D75 /* TTTLocationFormatter.m in Sources */,
+				5B31FE5D1CA6B4D400309D75 /* TTTURLRequestFormatter.m in Sources */,
 				F872625414FD3BED00800E11 /* UnitOfInformationFormatterViewController.m in Sources */,
 				F8A847A9161E98D800940F39 /* AddressFormatterViewController.m in Sources */,
 				F8202D0C17F50AF5006C5810 /* ColorFormatterViewController.m in Sources */,
-				F89C9F02166154AB0040FB03 /* TTTAddressFormatter.m in Sources */,
-				F89C9F03166154AB0040FB03 /* TTTArrayFormatter.m in Sources */,
-				F89C9F04166154AB0040FB03 /* TTTLocationFormatter.m in Sources */,
+				5B31FE5C1CA6B4D400309D75 /* TTTUnitOfInformationFormatter.m in Sources */,
 				F83F967F1982DAB90012B3AF /* NameFormatterViewController.m in Sources */,
-				F83F96821982DADF0012B3AF /* TTTNameFormatter.m in Sources */,
-				F89C9F05166154AB0040FB03 /* TTTOrdinalNumberFormatter.m in Sources */,
 				50E226D81C6863BF0088FAA5 /* AppDeletage.swift in Sources */,
-				F89C9F06166154AB0040FB03 /* TTTTimeIntervalFormatter.m in Sources */,
-				F89C9F07166154AB0040FB03 /* TTTUnitOfInformationFormatter.m in Sources */,
-				F89C9F08166154AB0040FB03 /* TTTURLRequestFormatter.m in Sources */,
-				F8202D0917F4FAAE006C5810 /* TTTColorFormatter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/FormatterKit Example.xcodeproj/xcshareddata/xcschemes/FormatterKit Example.xcscheme
+++ b/Example/FormatterKit Example.xcodeproj/xcshareddata/xcschemes/FormatterKit Example.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F8FBF9E31427A456001409DB"
+               BuildableName = "FormatterKit Example.app"
+               BlueprintName = "FormatterKit Example"
+               ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "659BF4B61AE27FA300CD4A06"
+               BuildableName = "FormatterKitTests.xctest"
+               BlueprintName = "FormatterKitTests"
+               ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8FBF9E31427A456001409DB"
+            BuildableName = "FormatterKit Example.app"
+            BlueprintName = "FormatterKit Example"
+            ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8FBF9E31427A456001409DB"
+            BuildableName = "FormatterKit Example.app"
+            BlueprintName = "FormatterKit Example"
+            ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8FBF9E31427A456001409DB"
+            BuildableName = "FormatterKit Example.app"
+            BlueprintName = "FormatterKit Example"
+            ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/FormatterKit Example/Main.storyboard
+++ b/Example/FormatterKit Example/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BDK-oB-sUH">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BDK-oB-sUH">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Root View Controller-->

--- a/FormatterKit.xcodeproj/project.pbxproj
+++ b/FormatterKit.xcodeproj/project.pbxproj
@@ -1,0 +1,609 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5B08B66D1CA69F99009541EC /* FormatterKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B66C1CA69F99009541EC /* FormatterKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6931CA6A0C3009541EC /* TTTAddressFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6811CA6A0C3009541EC /* TTTAddressFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6941CA6A0C3009541EC /* TTTAddressFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6811CA6A0C3009541EC /* TTTAddressFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6951CA6A0C3009541EC /* TTTAddressFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6821CA6A0C3009541EC /* TTTAddressFormatter.m */; };
+		5B08B6961CA6A0C3009541EC /* TTTAddressFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6821CA6A0C3009541EC /* TTTAddressFormatter.m */; };
+		5B08B6971CA6A0C3009541EC /* TTTArrayFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6831CA6A0C3009541EC /* TTTArrayFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6981CA6A0C3009541EC /* TTTArrayFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6831CA6A0C3009541EC /* TTTArrayFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6991CA6A0C3009541EC /* TTTArrayFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6841CA6A0C3009541EC /* TTTArrayFormatter.m */; };
+		5B08B69A1CA6A0C3009541EC /* TTTArrayFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6841CA6A0C3009541EC /* TTTArrayFormatter.m */; };
+		5B08B69B1CA6A0C3009541EC /* TTTColorFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6851CA6A0C3009541EC /* TTTColorFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B69C1CA6A0C3009541EC /* TTTColorFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6851CA6A0C3009541EC /* TTTColorFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B69D1CA6A0C3009541EC /* TTTColorFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6861CA6A0C3009541EC /* TTTColorFormatter.m */; };
+		5B08B69E1CA6A0C3009541EC /* TTTColorFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6861CA6A0C3009541EC /* TTTColorFormatter.m */; };
+		5B08B69F1CA6A0C3009541EC /* TTTLocationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6871CA6A0C3009541EC /* TTTLocationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6A01CA6A0C3009541EC /* TTTLocationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6871CA6A0C3009541EC /* TTTLocationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6A11CA6A0C3009541EC /* TTTLocationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6881CA6A0C3009541EC /* TTTLocationFormatter.m */; };
+		5B08B6A21CA6A0C3009541EC /* TTTLocationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6881CA6A0C3009541EC /* TTTLocationFormatter.m */; };
+		5B08B6A31CA6A0C3009541EC /* TTTNameFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6891CA6A0C3009541EC /* TTTNameFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6A41CA6A0C3009541EC /* TTTNameFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6891CA6A0C3009541EC /* TTTNameFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6A51CA6A0C3009541EC /* TTTNameFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B68A1CA6A0C3009541EC /* TTTNameFormatter.m */; };
+		5B08B6A61CA6A0C3009541EC /* TTTNameFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B68A1CA6A0C3009541EC /* TTTNameFormatter.m */; };
+		5B08B6A71CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B68B1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6A81CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B68B1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6A91CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B68C1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m */; };
+		5B08B6AA1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B68C1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m */; };
+		5B08B6AB1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B68D1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6AC1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B68D1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6AD1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B68E1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m */; };
+		5B08B6AE1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B68E1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m */; };
+		5B08B6AF1CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B68F1CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6B01CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B68F1CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6B11CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6901CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m */; };
+		5B08B6B21CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6901CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m */; };
+		5B08B6B31CA6A0C3009541EC /* TTTURLRequestFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6911CA6A0C3009541EC /* TTTURLRequestFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6B41CA6A0C3009541EC /* TTTURLRequestFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B6911CA6A0C3009541EC /* TTTURLRequestFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B08B6B51CA6A0C3009541EC /* TTTURLRequestFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6921CA6A0C3009541EC /* TTTURLRequestFormatter.m */; };
+		5B08B6B61CA6A0C3009541EC /* TTTURLRequestFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B08B6921CA6A0C3009541EC /* TTTURLRequestFormatter.m */; };
+		5B08B6B71CA6A26A009541EC /* FormatterKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B08B66C1CA69F99009541EC /* FormatterKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B31FE411CA6B47800309D75 /* FormatterKit.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5B31FE231CA6B47800309D75 /* FormatterKit.strings */; };
+		5B31FE421CA6B47800309D75 /* FormatterKit.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5B31FE231CA6B47800309D75 /* FormatterKit.strings */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		5B08B6691CA69F99009541EC /* FormatterKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FormatterKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B08B66C1CA69F99009541EC /* FormatterKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FormatterKit.h; sourceTree = "<group>"; };
+		5B08B66E1CA69F99009541EC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5B08B6791CA6A078009541EC /* FormatterKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FormatterKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B08B6811CA6A0C3009541EC /* TTTAddressFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTAddressFormatter.h; sourceTree = "<group>"; };
+		5B08B6821CA6A0C3009541EC /* TTTAddressFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTAddressFormatter.m; sourceTree = "<group>"; };
+		5B08B6831CA6A0C3009541EC /* TTTArrayFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTArrayFormatter.h; sourceTree = "<group>"; };
+		5B08B6841CA6A0C3009541EC /* TTTArrayFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTArrayFormatter.m; sourceTree = "<group>"; };
+		5B08B6851CA6A0C3009541EC /* TTTColorFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTColorFormatter.h; sourceTree = "<group>"; };
+		5B08B6861CA6A0C3009541EC /* TTTColorFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTColorFormatter.m; sourceTree = "<group>"; };
+		5B08B6871CA6A0C3009541EC /* TTTLocationFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTLocationFormatter.h; sourceTree = "<group>"; };
+		5B08B6881CA6A0C3009541EC /* TTTLocationFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTLocationFormatter.m; sourceTree = "<group>"; };
+		5B08B6891CA6A0C3009541EC /* TTTNameFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTNameFormatter.h; sourceTree = "<group>"; };
+		5B08B68A1CA6A0C3009541EC /* TTTNameFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTNameFormatter.m; sourceTree = "<group>"; };
+		5B08B68B1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTOrdinalNumberFormatter.h; sourceTree = "<group>"; };
+		5B08B68C1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTOrdinalNumberFormatter.m; sourceTree = "<group>"; };
+		5B08B68D1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTTimeIntervalFormatter.h; sourceTree = "<group>"; };
+		5B08B68E1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTTimeIntervalFormatter.m; sourceTree = "<group>"; };
+		5B08B68F1CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTUnitOfInformationFormatter.h; sourceTree = "<group>"; };
+		5B08B6901CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTUnitOfInformationFormatter.m; sourceTree = "<group>"; };
+		5B08B6911CA6A0C3009541EC /* TTTURLRequestFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TTTURLRequestFormatter.h; sourceTree = "<group>"; };
+		5B08B6921CA6A0C3009541EC /* TTTURLRequestFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TTTURLRequestFormatter.m; sourceTree = "<group>"; };
+		5B31FE241CA6B47800309D75 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE251CA6B47800309D75 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE261CA6B47800309D75 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE271CA6B47800309D75 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE281CA6B47800309D75 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE291CA6B47800309D75 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE2A1CA6B47800309D75 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE2B1CA6B47800309D75 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE2C1CA6B47800309D75 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE2D1CA6B47800309D75 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE2E1CA6B47800309D75 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE2F1CA6B47800309D75 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE301CA6B47800309D75 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE311CA6B47800309D75 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE321CA6B47800309D75 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE331CA6B47800309D75 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE341CA6B47800309D75 /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE351CA6B47800309D75 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE361CA6B47800309D75 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE371CA6B47800309D75 /* pt_BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt_BR; path = pt_BR.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE381CA6B47800309D75 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE391CA6B47800309D75 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE3A1CA6B47800309D75 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE3B1CA6B47800309D75 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE3C1CA6B47800309D75 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE3D1CA6B47800309D75 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE3E1CA6B47800309D75 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/FormatterKit.strings; sourceTree = "<group>"; };
+		5B31FE3F1CA6B47800309D75 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/FormatterKit.strings"; sourceTree = "<group>"; };
+		5B31FE401CA6B47800309D75 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/FormatterKit.strings"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5B08B6651CA69F99009541EC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B08B6751CA6A078009541EC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5B08B65F1CA69F99009541EC = {
+			isa = PBXGroup;
+			children = (
+				5B08B66B1CA69F99009541EC /* FormatterKit */,
+				5B31FE221CA6B47800309D75 /* Localizations */,
+				5B08B66A1CA69F99009541EC /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5B08B66A1CA69F99009541EC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5B08B6691CA69F99009541EC /* FormatterKit.framework */,
+				5B08B6791CA6A078009541EC /* FormatterKit.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5B08B66B1CA69F99009541EC /* FormatterKit */ = {
+			isa = PBXGroup;
+			children = (
+				5B08B6811CA6A0C3009541EC /* TTTAddressFormatter.h */,
+				5B08B6821CA6A0C3009541EC /* TTTAddressFormatter.m */,
+				5B08B6831CA6A0C3009541EC /* TTTArrayFormatter.h */,
+				5B08B6841CA6A0C3009541EC /* TTTArrayFormatter.m */,
+				5B08B6851CA6A0C3009541EC /* TTTColorFormatter.h */,
+				5B08B6861CA6A0C3009541EC /* TTTColorFormatter.m */,
+				5B08B6871CA6A0C3009541EC /* TTTLocationFormatter.h */,
+				5B08B6881CA6A0C3009541EC /* TTTLocationFormatter.m */,
+				5B08B6891CA6A0C3009541EC /* TTTNameFormatter.h */,
+				5B08B68A1CA6A0C3009541EC /* TTTNameFormatter.m */,
+				5B08B68B1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h */,
+				5B08B68C1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m */,
+				5B08B68D1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h */,
+				5B08B68E1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m */,
+				5B08B68F1CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h */,
+				5B08B6901CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m */,
+				5B08B6911CA6A0C3009541EC /* TTTURLRequestFormatter.h */,
+				5B08B6921CA6A0C3009541EC /* TTTURLRequestFormatter.m */,
+				5B08B66C1CA69F99009541EC /* FormatterKit.h */,
+				5B08B66E1CA69F99009541EC /* Info.plist */,
+			);
+			path = FormatterKit;
+			sourceTree = "<group>";
+		};
+		5B31FE221CA6B47800309D75 /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				5B31FE231CA6B47800309D75 /* FormatterKit.strings */,
+			);
+			path = Localizations;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		5B08B6661CA69F99009541EC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B08B69B1CA6A0C3009541EC /* TTTColorFormatter.h in Headers */,
+				5B08B6A31CA6A0C3009541EC /* TTTNameFormatter.h in Headers */,
+				5B08B6A71CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h in Headers */,
+				5B08B66D1CA69F99009541EC /* FormatterKit.h in Headers */,
+				5B08B6B31CA6A0C3009541EC /* TTTURLRequestFormatter.h in Headers */,
+				5B08B6AB1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h in Headers */,
+				5B08B69F1CA6A0C3009541EC /* TTTLocationFormatter.h in Headers */,
+				5B08B6931CA6A0C3009541EC /* TTTAddressFormatter.h in Headers */,
+				5B08B6AF1CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h in Headers */,
+				5B08B6971CA6A0C3009541EC /* TTTArrayFormatter.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B08B6761CA6A078009541EC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B08B6B71CA6A26A009541EC /* FormatterKit.h in Headers */,
+				5B08B6B01CA6A0C3009541EC /* TTTUnitOfInformationFormatter.h in Headers */,
+				5B08B6AC1CA6A0C3009541EC /* TTTTimeIntervalFormatter.h in Headers */,
+				5B08B6981CA6A0C3009541EC /* TTTArrayFormatter.h in Headers */,
+				5B08B6A41CA6A0C3009541EC /* TTTNameFormatter.h in Headers */,
+				5B08B6B41CA6A0C3009541EC /* TTTURLRequestFormatter.h in Headers */,
+				5B08B6A01CA6A0C3009541EC /* TTTLocationFormatter.h in Headers */,
+				5B08B6A81CA6A0C3009541EC /* TTTOrdinalNumberFormatter.h in Headers */,
+				5B08B6941CA6A0C3009541EC /* TTTAddressFormatter.h in Headers */,
+				5B08B69C1CA6A0C3009541EC /* TTTColorFormatter.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		5B08B6681CA69F99009541EC /* FormatterKit-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B08B6711CA69F99009541EC /* Build configuration list for PBXNativeTarget "FormatterKit-iOS" */;
+			buildPhases = (
+				5B08B6641CA69F99009541EC /* Sources */,
+				5B08B6651CA69F99009541EC /* Frameworks */,
+				5B08B6661CA69F99009541EC /* Headers */,
+				5B08B6671CA69F99009541EC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FormatterKit-iOS";
+			productName = FormatterKit;
+			productReference = 5B08B6691CA69F99009541EC /* FormatterKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5B08B6781CA6A078009541EC /* FormatterKit-OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B08B67E1CA6A078009541EC /* Build configuration list for PBXNativeTarget "FormatterKit-OSX" */;
+			buildPhases = (
+				5B08B6741CA6A078009541EC /* Sources */,
+				5B08B6751CA6A078009541EC /* Frameworks */,
+				5B08B6761CA6A078009541EC /* Headers */,
+				5B08B6771CA6A078009541EC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FormatterKit-OSX";
+			productName = "FormatterKit-OSX";
+			productReference = 5B08B6791CA6A078009541EC /* FormatterKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5B08B6601CA69F99009541EC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = FormatterKit;
+				TargetAttributes = {
+					5B08B6681CA69F99009541EC = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					5B08B6781CA6A078009541EC = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 5B08B6631CA69F99009541EC /* Build configuration list for PBXProject "FormatterKit" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				ar,
+				ca,
+				cs,
+				da,
+				de,
+				el,
+				es,
+				fr,
+				he,
+				id,
+				it,
+				ja,
+				ko,
+				nb,
+				nl,
+				nn,
+				pl,
+				pt,
+				pt_BR,
+				ro,
+				ru,
+				sv,
+				th,
+				tr,
+				uk,
+				vi,
+				"zh-Hans",
+				"zh-Hant",
+			);
+			mainGroup = 5B08B65F1CA69F99009541EC;
+			productRefGroup = 5B08B66A1CA69F99009541EC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5B08B6681CA69F99009541EC /* FormatterKit-iOS */,
+				5B08B6781CA6A078009541EC /* FormatterKit-OSX */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5B08B6671CA69F99009541EC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B31FE411CA6B47800309D75 /* FormatterKit.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B08B6771CA6A078009541EC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B31FE421CA6B47800309D75 /* FormatterKit.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5B08B6641CA69F99009541EC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B08B6A91CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m in Sources */,
+				5B08B6951CA6A0C3009541EC /* TTTAddressFormatter.m in Sources */,
+				5B08B6A51CA6A0C3009541EC /* TTTNameFormatter.m in Sources */,
+				5B08B6991CA6A0C3009541EC /* TTTArrayFormatter.m in Sources */,
+				5B08B6AD1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m in Sources */,
+				5B08B6B51CA6A0C3009541EC /* TTTURLRequestFormatter.m in Sources */,
+				5B08B6B11CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m in Sources */,
+				5B08B6A11CA6A0C3009541EC /* TTTLocationFormatter.m in Sources */,
+				5B08B69D1CA6A0C3009541EC /* TTTColorFormatter.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B08B6741CA6A078009541EC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B08B6AA1CA6A0C3009541EC /* TTTOrdinalNumberFormatter.m in Sources */,
+				5B08B6961CA6A0C3009541EC /* TTTAddressFormatter.m in Sources */,
+				5B08B6A61CA6A0C3009541EC /* TTTNameFormatter.m in Sources */,
+				5B08B69A1CA6A0C3009541EC /* TTTArrayFormatter.m in Sources */,
+				5B08B6AE1CA6A0C3009541EC /* TTTTimeIntervalFormatter.m in Sources */,
+				5B08B6B61CA6A0C3009541EC /* TTTURLRequestFormatter.m in Sources */,
+				5B08B6B21CA6A0C3009541EC /* TTTUnitOfInformationFormatter.m in Sources */,
+				5B08B6A21CA6A0C3009541EC /* TTTLocationFormatter.m in Sources */,
+				5B08B69E1CA6A0C3009541EC /* TTTColorFormatter.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		5B31FE231CA6B47800309D75 /* FormatterKit.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5B31FE241CA6B47800309D75 /* ar */,
+				5B31FE251CA6B47800309D75 /* ca */,
+				5B31FE261CA6B47800309D75 /* cs */,
+				5B31FE271CA6B47800309D75 /* da */,
+				5B31FE281CA6B47800309D75 /* de */,
+				5B31FE291CA6B47800309D75 /* el */,
+				5B31FE2A1CA6B47800309D75 /* en */,
+				5B31FE2B1CA6B47800309D75 /* es */,
+				5B31FE2C1CA6B47800309D75 /* fr */,
+				5B31FE2D1CA6B47800309D75 /* he */,
+				5B31FE2E1CA6B47800309D75 /* id */,
+				5B31FE2F1CA6B47800309D75 /* it */,
+				5B31FE301CA6B47800309D75 /* ja */,
+				5B31FE311CA6B47800309D75 /* ko */,
+				5B31FE321CA6B47800309D75 /* nb */,
+				5B31FE331CA6B47800309D75 /* nl */,
+				5B31FE341CA6B47800309D75 /* nn */,
+				5B31FE351CA6B47800309D75 /* pl */,
+				5B31FE361CA6B47800309D75 /* pt */,
+				5B31FE371CA6B47800309D75 /* pt_BR */,
+				5B31FE381CA6B47800309D75 /* ro */,
+				5B31FE391CA6B47800309D75 /* ru */,
+				5B31FE3A1CA6B47800309D75 /* sv */,
+				5B31FE3B1CA6B47800309D75 /* th */,
+				5B31FE3C1CA6B47800309D75 /* tr */,
+				5B31FE3D1CA6B47800309D75 /* uk */,
+				5B31FE3E1CA6B47800309D75 /* vi */,
+				5B31FE3F1CA6B47800309D75 /* zh-Hans */,
+				5B31FE401CA6B47800309D75 /* zh-Hant */,
+			);
+			name = FormatterKit.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		5B08B66F1CA69F99009541EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1.8.0;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5B08B6701CA69F99009541EC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1.8.0;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		5B08B6721CA69F99009541EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = FormatterKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.matt.FormatterKit.FormatterKit-iOS";
+				PRODUCT_NAME = FormatterKit;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5B08B6731CA69F99009541EC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = FormatterKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.matt.FormatterKit.FormatterKit-iOS";
+				PRODUCT_NAME = FormatterKit;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		5B08B67F1CA6A078009541EC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/FormatterKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.matt.FormatterKit.FormatterKit-OSX";
+				PRODUCT_NAME = FormatterKit;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5B08B6801CA6A078009541EC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/FormatterKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.matt.FormatterKit.FormatterKit-OSX";
+				PRODUCT_NAME = FormatterKit;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5B08B6631CA69F99009541EC /* Build configuration list for PBXProject "FormatterKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B08B66F1CA69F99009541EC /* Debug */,
+				5B08B6701CA69F99009541EC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5B08B6711CA69F99009541EC /* Build configuration list for PBXNativeTarget "FormatterKit-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B08B6721CA69F99009541EC /* Debug */,
+				5B08B6731CA69F99009541EC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5B08B67E1CA6A078009541EC /* Build configuration list for PBXNativeTarget "FormatterKit-OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B08B67F1CA6A078009541EC /* Debug */,
+				5B08B6801CA6A078009541EC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5B08B6601CA69F99009541EC /* Project object */;
+}

--- a/FormatterKit.xcodeproj/xcshareddata/xcschemes/FormatterKit-OSX.xcscheme
+++ b/FormatterKit.xcodeproj/xcshareddata/xcschemes/FormatterKit-OSX.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B08B6781CA6A078009541EC"
+               BuildableName = "FormatterKit.framework"
+               BlueprintName = "FormatterKit-OSX"
+               ReferencedContainer = "container:FormatterKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B08B6781CA6A078009541EC"
+            BuildableName = "FormatterKit.framework"
+            BlueprintName = "FormatterKit-OSX"
+            ReferencedContainer = "container:FormatterKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B08B6781CA6A078009541EC"
+            BuildableName = "FormatterKit.framework"
+            BlueprintName = "FormatterKit-OSX"
+            ReferencedContainer = "container:FormatterKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FormatterKit.xcodeproj/xcshareddata/xcschemes/FormatterKit-iOS.xcscheme
+++ b/FormatterKit.xcodeproj/xcshareddata/xcschemes/FormatterKit-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F8FBF9E31427A456001409DB"
-               BuildableName = "FormatterKit Example.app"
-               BlueprintName = "FormatterKit Example"
-               ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+               BlueprintIdentifier = "5B08B6681CA69F99009541EC"
+               BuildableName = "FormatterKit.framework"
+               BlueprintName = "FormatterKit-iOS"
+               ReferencedContainer = "container:FormatterKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -28,26 +28,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "659BF4B61AE27FA300CD4A06"
-               BuildableName = "FormatterKitTests.xctest"
-               BlueprintName = "FormatterKitTests"
-               ReferencedContainer = "container:FormatterKit Example.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F8FBF9E31427A456001409DB"
-            BuildableName = "FormatterKit Example.app"
-            BlueprintName = "FormatterKit Example"
-            ReferencedContainer = "container:FormatterKit Example.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -61,16 +42,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F8FBF9E31427A456001409DB"
-            BuildableName = "FormatterKit Example.app"
-            BlueprintName = "FormatterKit Example"
-            ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+            BlueprintIdentifier = "5B08B6681CA69F99009541EC"
+            BuildableName = "FormatterKit.framework"
+            BlueprintName = "FormatterKit-iOS"
+            ReferencedContainer = "container:FormatterKit.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -80,16 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F8FBF9E31427A456001409DB"
-            BuildableName = "FormatterKit Example.app"
-            BlueprintName = "FormatterKit Example"
-            ReferencedContainer = "container:FormatterKit Example.xcodeproj">
+            BlueprintIdentifier = "5B08B6681CA69F99009541EC"
+            BuildableName = "FormatterKit.framework"
+            BlueprintName = "FormatterKit-iOS"
+            ReferencedContainer = "container:FormatterKit.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/FormatterKit.xcworkspace/contents.xcworkspacedata
+++ b/FormatterKit.xcworkspace/contents.xcworkspacedata
@@ -1,64 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
-   <Group
-      location = "group:FormatterKit"
-      name = "FormatterKit">
-      <FileRef
-         location = "group:TTTAddressFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTAddressFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTArrayFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTArrayFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTColorFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTColorFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTLocationFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTLocationFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTNameFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTNameFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTOrdinalNumberFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTOrdinalNumberFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTTimeIntervalFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTTimeIntervalFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTUnitOfInformationFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTUnitOfInformationFormatter.m">
-      </FileRef>
-      <FileRef
-         location = "group:TTTURLRequestFormatter.h">
-      </FileRef>
-      <FileRef
-         location = "group:TTTURLRequestFormatter.m">
-      </FileRef>
-   </Group>
+   <FileRef
+      location = "group:FormatterKit.xcodeproj">
+   </FileRef>
    <FileRef
       location = "group:Example/FormatterKit Example.xcodeproj">
    </FileRef>

--- a/FormatterKit/FormatterKit.h
+++ b/FormatterKit/FormatterKit.h
@@ -1,0 +1,27 @@
+//
+//  FormatterKit.h
+//  FormatterKit
+//
+//  Created by Markus Chmelar on 26/03/16.
+//  Copyright © 2016 FormatterKit. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for FormatterKit.
+FOUNDATION_EXPORT double FormatterKitVersionNumber;
+
+//! Project version string for FormatterKit.
+FOUNDATION_EXPORT const unsigned char FormatterKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <FormatterKit/PublicHeader.h>
+
+#import <FormatterKit/TTTAddressFormatter.h>
+#import <FormatterKit/TTTArrayFormatter.h>
+#import <FormatterKit/TTTColorFormatter.h>
+#import <FormatterKit/TTTLocationFormatter.h>
+#import <FormatterKit/TTTNameFormatter.h>
+#import <FormatterKit/TTTOrdinalNumberFormatter.h>
+#import <FormatterKit/TTTTimeIntervalFormatter.h>
+#import <FormatterKit/TTTUnitOfInformationFormatter.h>
+#import <FormatterKit/TTTURLRequestFormatter.h>

--- a/FormatterKit/Info.plist
+++ b/FormatterKit/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.8.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FormatterKit [![Build Status](https://travis-ci.org/mattt/FormatterKit.svg?branch=master)](https://travis-ci.org/mattt/FormatterKit)
+# FormatterKit [![Build Status](https://travis-ci.org/mattt/FormatterKit.svg?branch=master)](https://travis-ci.org/mattt/FormatterKit) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 `FormatterKit` is a collection of well-crafted `NSFormatter` subclasses for things like units of information, distance, and relative time intervals. Each formatter abstracts away the complex business logic of their respective domain, so that you can focus on the more important aspects of your application.
 


### PR DESCRIPTION
This is a re-work of #176 because of merge conflicts and things have changed since.

I have tested these changes with Carthage and Cocoapods and both ways of adding FormatterKit to my project have worked in my tests.

A new project `FormatterKit.xcodeproj ` has been added to the Workspace `FormatterKit.xcworkspace`. Different than in #176 it was not necessary to delete the workspace anymore, Carthage is not confused about the Examples project anymore.

This new projects has targets for building iOS and OSX Frameworks, those targets are shared so Carthage can pick them up. It should be easy to later also add Framework Targets for tvOS and watchOS.

The location of all the source files has remained the same, so no changes to the podspec have been necessary.