### PR TITLE
Fix Dutch localization for "years"

### DIFF
--- a/Localizations/nl.lproj/FormatterKit.strings
+++ b/Localizations/nl.lproj/FormatterKit.strings
@@ -173,7 +173,7 @@
 "year" = "jaar";
 
 /* Year Unit (Plural) */
-"years" = "jaren";
+"years" = "jaar";
 
 /* Year Unit (Singular, Abbreviated) */
 "yr" = "jr.";


### PR DESCRIPTION
In Dutch, "years" should be translated as "jaar" instead of "jaren". 
You say "3 jaar" for "3 years", not "3 jaren".